### PR TITLE
fix high memory usage in speedtest 

### DIFF
--- a/h/mempool.h
+++ b/h/mempool.h
@@ -10,6 +10,8 @@
 
 #include <stdint.h>
 
+#define MAX_BUFFER_FACTOR   6
+
 extern int mempool_init (uint32_t memory_cap);
 extern void *mempool_alloc (int *size);
 extern void mempool_free (void *mem);

--- a/h/stream.h
+++ b/h/stream.h
@@ -14,7 +14,7 @@
 #define LIST_POISONING
 #include "list.h"
 
-#define STREAM_BUF_LEN   6000
+#define STREAM_BUF_LEN   (MAX_BUFFER_FACTOR * 1000)
 
 typedef struct _stream_t stream_t;
 

--- a/h/stream.h
+++ b/h/stream.h
@@ -46,7 +46,7 @@ typedef struct _stream_t {
     uint32_t            io_num;
     netbuf_t           *input;
     queue_t             output_q;
-    int                 output_q_len;
+    uint32_t            output_q_len;
     void               *proto_data;
     int                 obsolete;
     backpressure_state_t    bp_state;

--- a/src/amoeba_main.c
+++ b/src/amoeba_main.c
@@ -61,6 +61,7 @@ typedef struct {
 #ifdef MESSAGE_DEBUG
 uint64_t message_new_num;
 uint64_t message_free_num;
+uint64_t message_diff_max;
 #endif
 
 static task_t server_tasks[task_id_end];
@@ -289,7 +290,9 @@ sigint_cb (struct ev_loop *loop, ev_signal *w, int revents)
     }
 
 #ifdef MESSAGE_DEBUG
-    printf("Message stats: %ld, %ld\n", message_new_num, message_free_num);
+    printf("Message stats: %ld, %ld, %ld\n", message_new_num,
+                                             message_free_num,
+                                             message_diff_max);
 #endif
 
     mempool_output_stats();

--- a/src/json_config.c
+++ b/src/json_config.c
@@ -447,7 +447,7 @@ static jcfg_system_t *parse_config(const char *input)
         if (cfg->mode == server_mode) {
             cfg->memory_cap = 8;
         } else {
-            cfg->memory_cap = 4;
+            cfg->memory_cap = 6;
         }
     }
 

--- a/src/mempool.c
+++ b/src/mempool.c
@@ -15,15 +15,15 @@
 
 #define BUF128_NUM   256
 #define BUF320_NUM   256
-#define BUF640_NUM   32
+#define BUF640_NUM   16
 #define BUF6K_NUM    512
-#define BUFMAX_NUM   16
+#define BUFMAX_NUM   8
 
 #define BUF128_SIZE  128
 #define BUF320_SIZE  320
 #define BUF640_SIZE  640
-#define BUF6K_SIZE   (6*1024)
-#define BUFMAX_SIZE  (12*1024)
+#define BUF6K_SIZE  (MAX_BUFFER_FACTOR*1024)
+#define BUFMAX_SIZE  (MAX_BUFFER_FACTOR*2048)
 
 typedef struct {
     FixedMemPool  *pool;

--- a/src/socks5.c
+++ b/src/socks5.c
@@ -459,8 +459,10 @@ static int socks5_free(stream_t *s, void *m)
 static void socks5_bkpressure(stream_t *s, backpressure_state_t state)
 {
     socks5_stream_t *ss = (socks5_stream_t *)STREAM_PROTO_DATA(s);
-    send_backpressure(task_socks5, ss->target, (uint64_t)s,
-                      ss->upstream_id, state);
+    if (ss->upstream_id) {
+        send_backpressure(task_socks5, ss->target, (uint64_t)s,
+                          ss->upstream_id, state);
+    }
 }
 
 static proto_ctrl_t socks5_ctrl = {

--- a/src/transport.c
+++ b/src/transport.c
@@ -226,7 +226,7 @@ crypto_error(message_crypto_notify_t *m)
         /* If this is the first packet, crypto-id is not set yet */
         ts->crypto_id = m->crypto_id;
     }
-    stream_free(s);
+    ts->flags |= TRANS_DROP;
     crypto_err++;
     log_info("crypto error received.");
 }
@@ -307,7 +307,7 @@ static void transport_bkpressure(stream_t *s, backpressure_state_t state)
     } else {
         if (ts->downstream_id) {
             send_backpressure(task_transport, ts->peer_task,
-                              ts->downstream_id, ts->upstream_id, state);
+                              ts->downstream_id, (uint64_t)s, state);
         }
     }
 }

--- a/src/transport.c
+++ b/src/transport.c
@@ -557,6 +557,8 @@ transport_client_connect(message_connect_t *msg, msg_ev_ctx_t *ctx)
 
     if (is_https(&msg->type_addr)) {
         ts->reply_enc = 3500 + (((uint64_t)s >> 4) & 0xff);
+    } else {
+        ts->reply_enc = 0;
     }
 
     stream_attach(s, fd);


### PR DESCRIPTION
the backpressure from transport to socks5 doesn't work due to a parameter error.